### PR TITLE
Matches query mode to qrels file used

### DIFF
--- a/src/edu/nd/sirs/eval/Evaluate.java
+++ b/src/edu/nd/sirs/eval/Evaluate.java
@@ -266,21 +266,8 @@ public class Evaluate {
 			return 0;
 		}
 
-		Map<Integer, Integer> query_map = rels.get(q);
-		int doc_id;
-		for(int i = 0; i < tbl.size(); i++) {
-			doc_id = tbl.get(i);
-			if(query_map.containsKey(doc_id) && 
-			   query_map.get(doc_id) > REL_THRESH) {
-				//Assume 3 and up are relevant, 2, 1 and 0 are not
-				//Add 1 / place in relevance list to sumMRR, which
-				//will later be divided by number of queries to get
-				//MRR.
-				return ((float) 1) / (i + 1);  //i+1 for 0 indexing
-			}
-		}
-
-		return 0;   // Essentially 1 / +inf
+		//TODO: Add code to calculate the mean reciprocal rank
+		return 0;
 	}
 
 	private float calcAvgPrec(List<Integer> tbl, String q) {
@@ -289,23 +276,8 @@ public class Evaluate {
 			return 0;
 		}
 
-		int recall_points = 0;
-		float precision_sum = 0;
-		Map<Integer, Integer> query_map = rels.get(q);
-		int doc_id;
-		for(int i = 0; i < tbl.size(); i++) {
-			doc_id = tbl.get(i);
-			if(query_map.containsKey(doc_id) && 
-			   query_map.get(doc_id) > REL_THRESH) {
-				//Assume 3 and up are relevant, 2, 1 and 0 are not
-				//Add precision at k (i) to precision_sum, which
-				//will later be divided by recall_points to get AvgPrecision
-				precision_sum += calcPrecision(tbl, q, i);
-				recall_points++;
-			}
-		}
-
-		return recall_points > 0 ? precision_sum / recall_points : 0;
+		//TODO: Add code to calculate the average precisions. Super hint: use the precision function!
+		return 0;
 	}
 
 	private float calcF(float precision, float recall, int beta) {
@@ -435,7 +407,6 @@ public class Evaluate {
 			logger.error(dir + " not a directory of files.");
 			System.exit(1);
 		}
-
 		return dir.listFiles(new FilenameFilter() {
 			/**
 			 * Only accept files within the directory... do not recur into

--- a/src/edu/nd/sirs/webapp/searcher.jsp
+++ b/src/edu/nd/sirs/webapp/searcher.jsp
@@ -34,28 +34,31 @@
 	Matching m = null;
 %>
 <%
+    Integer file_to_use = 0;
 	switch (model) {
 	case "Boolean":
 		m = new Matching(new BooleanRM());
 		Fields.getInstance().assignWeights(wgts);
 		m.addScoreModifier(new BooleanScoreModifier());
 		rs = m.match(new Query(query));
+		file_to_use = 1;
 		break;
 	case "Cosine":
 		m = new Matching(new CosineRM());
 		Fields.getInstance().assignWeights(wgts);
 		m.addScoreModifier(new CosineScoreModifier());
 		rs = m.match(new Query(query));
+		file_to_use = 2;
 		break;
 	}
 
 	StringBuffer json_r = new StringBuffer();
 
-	Evaluate g = new Evaluate();
+	Evaluate g = new Evaluate(file_to_use);
 	EvaluationResults er = g.evaluate(rs, query, 10);
 
 	for (int i = 0; i < rs.getResultSize(); i++) {
-		int docid = rs.getDocids()[i];
+		Integer docid = rs.getDocids()[i];
 		HTMLDocument doc = (HTMLDocument) DirectIndex.getInstance()
 				.getDoc(docid, HTMLDocument.class);
 		Object title = doc.getResources().get("title");


### PR DESCRIPTION
Addresses Piazza comment qrels issues from 7:58PM EST on 2/29/2016.
It's not pretty, but it makes the Evaluate constructor select a mode for the qrels file, then does string comparisons for specifically named qrels files, defaulting to the erroneous strategy of using any files in the qrels folder at its leisure if the file names don't match up.